### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Liana_vcc_2
 This Assignment 2 repository is for learning Git.
-This assignment teaches the important fundamentals of git, and how the terminal,branches,merges and issues work! 
+This assignment teaches the important fundamentals of Git, and how the terminal, branches, merges, and issues work! 


### PR DESCRIPTION
Closed #1 

This pull request addresses the following changes in README.md:

1. Corrected the capitalization of "git" to "Git" in accordance with proper noun conventions.

2. Fixed missing spaces and added appropriate commas in the sentence:
・From: "terminal,branches,merges and issues"
・To: "terminal, branches, merges, and issues"

If you have any questions or need further clarification, please feel free to reach out.
